### PR TITLE
Improve image processing on Android

### DIFF
--- a/android/src/main/java/com/michaelwolz/capacitorcameraview/CameraViewPlugin.kt
+++ b/android/src/main/java/com/michaelwolz/capacitorcameraview/CameraViewPlugin.kt
@@ -73,7 +73,7 @@ class CameraViewPlugin : Plugin() {
 
     @PluginMethod
     fun capture(call: PluginCall) {
-        val quality = call.getInt("quality", 90)
+        val quality = call.getInt("quality") ?: 90
 
         if (quality !in 0..100) {
             call.reject("Quality must be between 0 and 100")


### PR DESCRIPTION
Change handling of images on Android by outsourcing them to temp files instead of handling them in memory which will make base64 encoding easier and more performant